### PR TITLE
Add OpenAI timeline summarizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,8 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 ## Deployment and Environment
 
 ### Environment Variables
-- `VITE_BRAVE_SEARCH_API_KEY`: Required for news search functionality
-- `VITE_OPENAI_API_KEY`: Required for LLM based timeline summarisation and formatting
+- `BRAVE_SEARCH_API_KEY`: Required for news search functionality
+- `OPENAI_API_KEY`: Required for LLM based timeline summarisation and formatting
 - `NODE_ENV`: Set to 'development' or 'production'
 - `PORT`: Server port (defaults to 5000)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,8 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 ## Deployment and Environment
 
 ### Environment Variables
-- `BRAVE_SEARCH_API_KEY`: Required for news search functionality
+- `VITE_BRAVE_SEARCH_API_KEY`: Required for news search functionality
+- `VITE_OPENAI_API_KEY`: Required for LLM based timeline summarisation and formatting
 - `NODE_ENV`: Set to 'development' or 'production'
 - `PORT`: Server port (defaults to 5000)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 - **Timeline View**: Articles are displayed chronologically (newest first) in a Twitter/Google News-style feed
 - **Source Filtering**: Filter results by trusted news sources (Guardian, NYT, Verge, Wired, etc.)
 - **Live Data**: No mock data - all results are fetched live from the Brave Search API
+- **AI Timeline Summaries**: Search results can be summarized into structured timeline entries using OpenAI
 
 ## Technical Architecture
 
@@ -64,7 +65,7 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 - Files: kebab-case (e.g., `news-article-card.tsx`)
 - Variables/functions: camelCase
 - Constants: SCREAMING_SNAKE_CASE
-- API endpoints: RESTful conventions (`/api/news/search`)
+- API endpoints: RESTful conventions (`/api/news/search`, `/api/news/timeline`)
 
 ### API Integration Standards
 
@@ -74,6 +75,11 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 - Use proper TypeScript interfaces for API responses
 - Filter results to trusted news sources only
 - Implement reasonable timeouts (15 seconds max)
+
+#### OpenAI Timeline Summarization
+- Use the official `openai` package with Zod schema validation
+- Request structured JSON output for timeline entries
+- Limit summarization calls to 20 articles per request
 
 #### Error Handling
 - Log all API errors with timestamps and query details
@@ -140,12 +146,16 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 - `BRAVE_SEARCH_API_KEY`: Required for news search functionality
 - `OPENAI_API_KEY`: Required for LLM based timeline summarisation and formatting
 - `NODE_ENV`: Set to 'development' or 'production'
-- `PORT`: Server port (defaults to 5000)
+- `PORT`: Server port (defaults to 5174)
 
 ### Build Process
 - Frontend: `npm run build` (Vite builds to `dist/public`)
 - Backend: Runs with `tsx` in development, `node` in production
 - No database migrations required (uses in-memory storage)
+
+### Running the App
+- Development: `npm run dev` (frontend) and `npm run dev:server` (backend)
+- Production: `npm run start` (serve built client) or `npm run start:server` to run the API directly
 
 ### Performance Considerations
 - API calls typically take 1-2 seconds
@@ -168,7 +178,7 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 ### Backend Issues
 - **CORS errors**: Verify Express CORS configuration
 - **TypeScript errors**: Check type definitions in shared schemas
-- **Port conflicts**: Ensure port 5000 is available
+ - **Port conflicts**: Ensure port 5174 is available
 
 ## Feature Development Guidelines
 
@@ -228,6 +238,6 @@ NewsTracker is a real-time news monitoring web application that provides chronol
 
 ---
 
-**Last Updated**: June 13, 2025
+**Last Updated**: June 14, 2025
 **Version**: 1.0.0
 **Maintainer**: AI Agent Development Team

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -28,6 +28,22 @@ export interface NewsArticle {
   topic: string;
 }
 
+export interface TimelineEntry {
+  date: string;
+  mainTitle: string;
+  description: string;
+  coverImage?: string | null;
+  sources: { name: string; url: string }[];
+}
+
+export interface TimelineSummary {
+  entries: TimelineEntry[];
+  query: string;
+  resultCount: number;
+  sources?: string[];
+  daysBack: number;
+}
+
 export interface PopularSearch {
   id: number;
   query: string;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import Header from "@/components/header";
 import SearchSection from "@/components/search-section";
 import NewsTimeline from "@/components/news-timeline";
@@ -13,9 +13,16 @@ export default function Home() {
 
   const [isSearchActive, setIsSearchActive] = useState(false);
 
+  // Add a ref to NewsTimeline
+  const timelineRef = useRef<{ refetchTimeline: () => void }>(null);
+
   const handleSearch = (filters: SearchFilters) => {
     setSearchFilters(filters);
     setIsSearchActive(true);
+    // Call refetchTimeline after filters are set
+    setTimeout(() => {
+      timelineRef.current?.refetchTimeline();
+    }, 0);
   };
 
   return (
@@ -24,6 +31,7 @@ export default function Home() {
       <SearchSection onSearch={handleSearch} />
       {isSearchActive && (
         <NewsTimeline 
+          ref={timelineRef}
           searchFilters={searchFilters}
           onFiltersChange={setSearchFilters}
         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "@types/ws": "^8.5.13",
         "@vitejs/plugin-react": "^4.3.2",
         "autoprefixer": "^10.4.20",
+        "dotenv": "^16.5.0",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "postcss": "^8.4.47",
@@ -4553,6 +4554,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "memorystore": "^1.6.7",
         "next-themes": "^0.4.6",
         "node-html-parser": "^7.0.1",
+        "openai": "^4.104.0",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "react": "^18.3.1",
@@ -3483,6 +3484,16 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/passport": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
@@ -3622,6 +3633,18 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -3633,6 +3656,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -5348,6 +5383,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -5604,6 +5648,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -5921,6 +5984,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -6625,6 +6697,46 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
@@ -6741,6 +6853,51 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.111",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
+      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
@@ -8194,6 +8351,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -9374,6 +9537,21 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -9405,6 +9583,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "vite",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "memorystore": "^1.6.7",
     "next-themes": "^0.4.6",
     "node-html-parser": "^7.0.1",
+    "openai": "^4.104.0",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
+    "dotenv": "^16.5.0",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "postcss": "^8.4.47",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
+    "dev:server": "vite server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
+    "start:server": "NODE_ENV=production tsx server/index.ts",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,15 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import dotenv from "dotenv";
+import cors from "cors";
+
+dotenv.config();
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(cors());
 
 app.use((req, res, next) => {
   const start = Date.now();
@@ -59,7 +64,7 @@ app.use((req, res, next) => {
   // ALWAYS serve the app on port 5000
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const port = 5000;
+  const port = 5174;
   server.listen({
     port,
     host: "0.0.0.0",

--- a/server/news-api.ts
+++ b/server/news-api.ts
@@ -34,7 +34,7 @@ interface BraveSearchResponse {
 }
 
 export class NewsAPI {
-  private readonly apiKey = import.meta.env.VITE_BRAVE_SEARCH_API_KEY;
+  private readonly apiKey = process.env.BRAVE_SEARCH_API_KEY;
   private readonly baseUrl = 'https://api.search.brave.com/res/v1/web/search';  
   
   async searchNews(query: string, daysBack: number = 7): Promise<ScrapedArticle[]> {
@@ -63,9 +63,6 @@ export class NewsAPI {
         },
         timeout: 15000
       };
-      
-      console.log(`Request URL: ${this.baseUrl}`);
-      console.log(`Request params:`, requestConfig.params);
       
       const response = await axios.get<BraveSearchResponse>(this.baseUrl, requestConfig);
       

--- a/server/news-api.ts
+++ b/server/news-api.ts
@@ -34,10 +34,11 @@ interface BraveSearchResponse {
 }
 
 export class NewsAPI {
-  private readonly apiKey = process.env.BRAVE_SEARCH_API_KEY;
-  private readonly baseUrl = 'https://api.search.brave.com/res/v1/web/search';
+  private readonly apiKey = import.meta.env.VITE_BRAVE_SEARCH_API_KEY;
+  private readonly baseUrl = 'https://api.search.brave.com/res/v1/web/search';  
   
   async searchNews(query: string, daysBack: number = 7): Promise<ScrapedArticle[]> {
+    console.log(`Brave Search API Key: ${this.apiKey}`);
     if (!this.apiKey) {
       console.error('Brave Search API key not found');
       return [];

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "newschronos-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "newschronos-server",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "cors": "^2.8.5"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.19"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "newschronos-server",
+  "version": "1.0.0",
+  "description": "News Timeline Summariser",
+  "main": "index.ts",
+  "scripts": {
+    "dev": "bun run index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "news",
+    "ai",
+    "timeline",
+    "news-feed"
+  ],
+  "author": "Utkarsh Mishra",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.19"
+  }
+}

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -34,7 +34,7 @@ interface BraveSearchResponse {
 }
 
 export class NewsScraper {
-  private readonly apiKey = import.meta.env.VITE_BRAVE_SEARCH_API_KEY;
+  private readonly apiKey = process.env.BRAVE_SEARCH_API_KEY;
   private readonly baseUrl = 'https://api.search.brave.com/res/v1/news/search';
   
   async scrapeNews(query: string, daysBack: number = 7): Promise<ScrapedArticle[]> {

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -34,7 +34,7 @@ interface BraveSearchResponse {
 }
 
 export class NewsScraper {
-  private readonly apiKey = process.env.BRAVE_SEARCH_API_KEY;
+  private readonly apiKey = import.meta.env.VITE_BRAVE_SEARCH_API_KEY;
   private readonly baseUrl = 'https://api.search.brave.com/res/v1/news/search';
   
   async scrapeNews(query: string, daysBack: number = 7): Promise<ScrapedArticle[]> {

--- a/server/summarizer.ts
+++ b/server/summarizer.ts
@@ -1,0 +1,55 @@
+import OpenAI from "openai";
+import { z } from "zod";
+import { zodTextFormat } from "openai/helpers/zod";
+import type { NewsArticle } from "@shared/schema";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const SourceSchema = z.object({
+  name: z.string(),
+  url: z.string().url(),
+});
+
+const TimelineEntrySchema = z.object({
+  date: z.string(),
+  mainTitle: z.string(),
+  description: z.string(),
+  coverImage: z.string().url().nullable().optional(),
+  sources: z.array(SourceSchema),
+});
+
+const TimelineSchema = z.object({
+  entries: z.array(TimelineEntrySchema),
+});
+
+export type TimelineEntry = z.infer<typeof TimelineEntrySchema>;
+export type TimelineSummary = z.infer<typeof TimelineSchema>;
+
+export async function summarizeTimeline(articles: NewsArticle[]): Promise<TimelineSummary> {
+  const systemPrompt =
+    "You summarize news articles into a concise timeline grouped by day. If a day has few articles, group by week. For each period, identify the dominant topic or most frequently mentioned event and use it as `mainTitle`. Provide a short description summarizing key points and briefly mention minor topics. Quote key statements verbatim with attribution using the article source. Choose a representative `coverImage` from one of the articles if available. Include a list of sources with their URLs. Respond strictly using the provided JSON schema.";
+
+  const userPrompt = JSON.stringify(
+    articles.map((a) => ({
+      title: a.title,
+      excerpt: a.excerpt,
+      source: a.source,
+      publishedAt: a.publishedAt,
+      imageUrl: a.imageUrl,
+      articleUrl: a.articleUrl,
+    }))
+  );
+
+  const response = await openai.responses.parse({
+    model: "gpt-4o-2024-08-06",
+    input: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ],
+    text: {
+      format: zodTextFormat(TimelineSchema, "timeline"),
+    },
+  });
+
+  return response.output_parsed as TimelineSummary;
+}

--- a/server/summarizer.ts
+++ b/server/summarizer.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 import { zodTextFormat } from "openai/helpers/zod";
 import type { NewsArticle } from "@shared/schema";
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAI({ apiKey: import.meta.env.VITE_OPENAI_API_KEY });
+console.log(`OpenAI API Key: ${import.meta.env.VITE_OPENAI_API_KEY}`)
 
 const SourceSchema = z.object({
   name: z.string(),

--- a/server/summarizer.ts
+++ b/server/summarizer.ts
@@ -3,19 +3,18 @@ import { z } from "zod";
 import { zodTextFormat } from "openai/helpers/zod";
 import type { NewsArticle } from "@shared/schema";
 
-const openai = new OpenAI({ apiKey: import.meta.env.VITE_OPENAI_API_KEY });
-console.log(`OpenAI API Key: ${import.meta.env.VITE_OPENAI_API_KEY}`)
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const SourceSchema = z.object({
   name: z.string(),
-  url: z.string().url(),
+  url: z.string(),
 });
 
 const TimelineEntrySchema = z.object({
   date: z.string(),
   mainTitle: z.string(),
   description: z.string(),
-  coverImage: z.string().url().nullable().optional(),
+  coverImage: z.string().nullable().optional(),
   sources: z.array(SourceSchema),
 });
 
@@ -28,7 +27,7 @@ export type TimelineSummary = z.infer<typeof TimelineSchema>;
 
 export async function summarizeTimeline(articles: NewsArticle[]): Promise<TimelineSummary> {
   const systemPrompt =
-    "You summarize news articles into a concise timeline grouped by day. If a day has few articles, group by week. For each period, identify the dominant topic or most frequently mentioned event and use it as `mainTitle`. Provide a short description summarizing key points and briefly mention minor topics. Quote key statements verbatim with attribution using the article source. Choose a representative `coverImage` from one of the articles if available. Include a list of sources with their URLs. Respond strictly using the provided JSON schema.";
+    "You summarize news articles into a concise timeline, breaking down the timeline as granularly as possible, with a minimum breakdown by individual days. Always group articles by their `publishedAt` date, ensuring that news reported on different days is represented in separate timeline entries. Only group by week if there are no articles for several consecutive days. For each period, identify the dominant topic or most frequently mentioned event and use it as `mainTitle`. Provide a short description summarizing key points and briefly mention minor topics. Quote key statements verbatim with attribution using the article source. Choose a representative `coverImage` from one of the articles if available. Include a list of sources with their URLs. Respond strictly using the provided JSON schema.";
 
   const userPrompt = JSON.stringify(
     articles.map((a) => ({
@@ -40,6 +39,7 @@ export async function summarizeTimeline(articles: NewsArticle[]): Promise<Timeli
       articleUrl: a.articleUrl,
     }))
   );
+
 
   const response = await openai.responses.parse({
     model: "gpt-4o-2024-08-06",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
+
 export default defineConfig({
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- integrate OpenAI client
- add summarizer to group articles by time period
- expose `/api/news/timeline` endpoint
- update timeline component to render summarized entries
- define timeline types
- install OpenAI dependency

## Testing
- `npm run check` *(fails: error TS18046 and others in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684caffcee68832081a5124ff1fec472